### PR TITLE
New geometry type.

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -189,6 +189,43 @@ CSG.cube = function(options) {
   }));
 };
 
+// Construct an axis-aligned solid cuboid. Optional parameters are `center` and
+// `radius`, which default to `[0, 0, 0]` and `[1, 1, 1]`.
+//
+// Example code:
+//
+//     var cube = CSG.cube({
+//       center: [0, 0, 0],
+//       radius: 1
+//     });
+CSG.cuboid = function(options) {
+  options = options || {};
+  var c = new CSG.Vector(options.center || [0, 0, 0]);
+  var r = ( !options.radius ) ?
+           ( [ 1, 1, 1 ] ) :
+           ( options.radius.length ?
+             options.radius :
+             [ options.radius, options.radius, options.radius ]
+           );
+  return CSG.fromPolygons([
+    [[0, 4, 6, 2], [-1, 0, 0]],
+    [[1, 3, 7, 5], [+1, 0, 0]],
+    [[0, 1, 5, 4], [0, -1, 0]],
+    [[2, 6, 7, 3], [0, +1, 0]],
+    [[0, 2, 3, 1], [0, 0, -1]],
+    [[4, 5, 7, 6], [0, 0, +1]]
+  ].map(function(info) {
+    return new CSG.Polygon(info[0].map(function(i) {
+      var pos = new CSG.Vector(
+        c.x + r[0] * (2 * !!(i & 1) - 1),
+        c.y + r[1] * (2 * !!(i & 2) - 1),
+        c.z + r[2] * (2 * !!(i & 4) - 1)
+      );
+      return new CSG.Vertex(pos, new CSG.Vector(info[1]));
+    }));
+  }));
+};
+
 // Construct a solid sphere. Optional parameters are `center`, `radius`,
 // `slices`, and `stacks`, which default to `[0, 0, 0]`, `1`, `16`, and `8`.
 // The `slices` and `stacks` parameters control the tessellation along the


### PR DESCRIPTION
Added a simple new geometry type, a cuboid, follows the same syntax as CSG.cube but options.radius can be an array of 3 values which will be size of the created cuboid.
