### PR TITLE
Qualify "coplanar" in the documentation

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -23,10 +23,11 @@
 //     b.clipTo(a);
 //     a.build(b.allPolygons());
 // 
-// The only tricky part is handling overlapping coplanar polygons in both trees.
-// The code above keeps both copies, but we need to keep them in one tree and
-// remove them in the other tree. To remove them from `b` we can clip the
-// inverse of `b` against `a`. The code for union now looks like this:
+// The only tricky part is handling overlapping coplanar (same normal direction)
+// polygons in both trees. The code above keeps both copies, but we need to keep 
+// them in one tree and remove them in the other tree. To remove them from `b` we
+// can clip the inverse of `b` against `a`. The code for union now looks like
+// this:
 // 
 //     a.clipTo(b);
 //     b.clipTo(a);


### PR DESCRIPTION
_I understand this code isn't actively maintained, but hopefully this pull request will help others understand it correctly._

The code uses the word "coplanar" to refer to two specific conditions: overlapping polygons with the same normal direction and overlapping polygons with reversed normal directions: https://github.com/evanw/csg.js/blob/a8512afbac3cf503195870f7ef11c0a32f36c6d4/csg.js#L439)  

The documentation, on the other hand, uses it in one specific way: overlapping polygons with the same normal direction. But, it doesn't doesn't qualify. I think this qualification is key to understanding the algorithm correctly, so it is worth adding.

Namely, `clipTo` will return polygons in the argument list with the same normal direction as the `CSGNode`, but removes coplanar polygons with a reversed normal.
